### PR TITLE
Getting it to work on ACAD 2017+

### DIFF
--- a/releases/ALUnit-v1.0.lsp
+++ b/releases/ALUnit-v1.0.lsp
@@ -392,11 +392,9 @@ SOFTWARE.
 			(mapcar
 				'(lambda (testName)
 					(setq *ALU:currentTestName* testName)
-					(foreach
-						testExpression
+					(eval
 						(cdr
-							(assoc testName *ALU:allTests*))
-						(eval testExpression)))
+							(assoc testName *ALU:allTests*))))
 				(cdr testSuite))
 			(ALU:printElapsedTime)
 			(ALU:printTestInfo))
@@ -415,16 +413,14 @@ SOFTWARE.
  | @output: Standard ALUnit output.
  |;
 
-(defun runTest ( testName / testExpression)
+(defun runTest ( testName )
 	(ALU:resetTestInfo)
 	(ALU:printOutputHeader)
 	(ALU:startTimer)
 	(setq *ALU:currentTestName* testName)
-	(foreach
-		testExpression
+	(eval
 		(cdr
-			(assoc testName *ALU:allTests*))
-		(eval testExpression))
+			(assoc testName *ALU:allTests*)))
 	(ALU:printElapsedTime)
 	(ALU:printTestInfo)
 	(print))

--- a/releases/ALUnit-v1.0.lsp
+++ b/releases/ALUnit-v1.0.lsp
@@ -304,7 +304,7 @@ SOFTWARE.
  | *ALU:testSuites* - assoc list of test suites and a list of their tests
  | *ALU:testsRun* - counter for total tests run in the current batch
  | *ALU:failMessages* - list of messages to print after testing
- | *ALU:startTime* - date number for start of testing
+ | *ALU:startTime* - milliseconds since boot time for start of testing
  | *ALU:currentTestName* - name of test currently running
  |; 
 
@@ -473,7 +473,7 @@ SOFTWARE.
 (defun ALU:startTimer ( / )
 	(setq 
 		*ALU:startTime*
-		(getvar "date"))
+		(getvar "millisecs"))
 	(princ))
 
 
@@ -482,20 +482,16 @@ SOFTWARE.
  | @output: Elapsed time in milliseconds.
  |;
  
-(defun ALU:printElapsedTime ( / MILLISEC_CONVERSION DECIMAL_FORMAT
-										  ZERO_DECIMAL_PLACES)
-	(setq MILLISEC_CONVERSION 86400000
-			DECIMAL_FORMAT 2
+(defun ALU:printElapsedTime ( / DECIMAL_FORMAT ZERO_DECIMAL_PLACES)
+	(setq DECIMAL_FORMAT 2
 			ZERO_DECIMAL_PLACES 0)
 	(princ
 		(strcat
 			"\nTime: "
 			(rtos
-				(*
-					MILLISEC_CONVERSION
-					(-
-						(getvar "date")
-						*ALU:startTime*))
+				(-
+					(getvar "millisecs")
+					*ALU:startTime*)
 				DECIMAL_FORMAT
 				ZERO_DECIMAL_PLACES)
 			" ms"))

--- a/src/Test.lsp
+++ b/src/Test.lsp
@@ -22,7 +22,7 @@
  | *ALU:testSuites* - assoc list of test suites and a list of their tests
  | *ALU:testsRun* - counter for total tests run in the current batch
  | *ALU:failMessages* - list of messages to print after testing
- | *ALU:startTime* - date number for start of testing
+ | *ALU:startTime* - milliseconds since boot time for start of testing
  | *ALU:currentTestName* - name of test currently running
  |; 
 
@@ -110,11 +110,9 @@
 			(mapcar
 				'(lambda (testName)
 					(setq *ALU:currentTestName* testName)
-					(foreach
-						testExpression
+					(eval
 						(cdr
-							(assoc testName *ALU:allTests*))
-						(eval testExpression)))
+							(assoc testName *ALU:allTests*))))
 				(cdr testSuite))
 			(ALU:printElapsedTime)
 			(ALU:printTestInfo))
@@ -133,16 +131,14 @@
  | @output: Standard ALUnit output.
  |;
 
-(defun runTest ( testName / testExpression)
+(defun runTest ( testName )
 	(ALU:resetTestInfo)
 	(ALU:printOutputHeader)
 	(ALU:startTimer)
 	(setq *ALU:currentTestName* testName)
-	(foreach
-		testExpression
+	(eval
 		(cdr
-			(assoc testName *ALU:allTests*))
-		(eval testExpression))
+			(assoc testName *ALU:allTests*)))
 	(ALU:printElapsedTime)
 	(ALU:printTestInfo)
 	(print))
@@ -195,7 +191,7 @@
 (defun ALU:startTimer ( / )
 	(setq 
 		*ALU:startTime*
-		(getvar "date"))
+		(getvar "millisecs"))
 	(princ))
 
 
@@ -204,20 +200,16 @@
  | @output: Elapsed time in milliseconds.
  |;
  
-(defun ALU:printElapsedTime ( / MILLISEC_CONVERSION DECIMAL_FORMAT
-										  ZERO_DECIMAL_PLACES)
-	(setq MILLISEC_CONVERSION 86400000
-			DECIMAL_FORMAT 2
+(defun ALU:printElapsedTime ( / DECIMAL_FORMAT ZERO_DECIMAL_PLACES)
+	(setq DECIMAL_FORMAT 2
 			ZERO_DECIMAL_PLACES 0)
 	(princ
 		(strcat
 			"\nTime: "
 			(rtos
-				(*
-					MILLISEC_CONVERSION
-					(-
-						(getvar "date")
-						*ALU:startTime*))
+				(-
+					(getvar "millisecs")
+					*ALU:startTime*)
 				DECIMAL_FORMAT
 				ZERO_DECIMAL_PLACES)
 			" ms"))


### PR DESCRIPTION
It didn't seem to work for ACAD 2018 or 2020 (tested on C3D vertical). The ACAD `date` variable was silently changed in ACAD 2017+, so it broke the timer functionality.

Known issues:
- The test time outputs 0ms sometimes if the test takes under ~15ms, even if running the same test back to back. It seems to be related to ACAD not refreshing the counter often enough, though I'm not sure.

Example success:
```
ALUnit version 1.0
.......
Time: 62 ms

OK (7 tests run)
```

Example failure:
```
ALUnit version 1.0
......X
Time: 0 ms
1. round-num-test(NOT (nil)) returned T instead of nil.

FAILURES!!!
Tests run: 7, Failures: 1
```